### PR TITLE
Make it an Event Dispatcher decorator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,17 @@ To use in a [Silex](http://silex.sensiolabs.org) application:
 ``` php
 <?php
 
+use PimpleAwareEventDispatcher\PimpleAwareEventDispatcher;
 use Silex\Application;
 
 $app = new Application;
 
 // override the dispatcher
-$app['dispatcher_class'] = "PimpleAwareEventDispatcher\PimpleAwareEventDispatcher";
-$app['dispatcher']->extend('dispatcher', function($dispatcher) use ($app) {
-    $dispatcher->setContainer($app);
-    return $dispatcher;
-});
+$app['dispatcher'] = $app['pimple_aware_dispatcher'] = $app->share(
+    $app->extend('dispatcher', function($dispatcher) use ($app) {
+        return new PimpleContainerAwareEventDispatcher($dispatcher, $app);
+    }
+));
 
 // define our application services
 $app['some.service'] = $app->share(function() use ($app) {
@@ -36,7 +37,9 @@ $app['some.service'] = $app->share(function() use ($app) {
 });
 
 // add a listener, that will lazily fetch the service when needed
-$app['dispatcher']->addListenerService("some.event", array("some.service", "serviceMethod"));
-
+$app['pimple_aware_dispatcher']->addListenerService(
+    "some.event",
+    array("some.service", "serviceMethod")
+);
 ```
 

--- a/tests/PimpleAwareEventDispatcher/Test/PimpleAwareEventDispatcherTest.php
+++ b/tests/PimpleAwareEventDispatcher/Test/PimpleAwareEventDispatcherTest.php
@@ -14,6 +14,7 @@ namespace PimpleAwareEventDispatcher\Test;
 use Pimple;
 use PimpleAwareEventDispatcher\PimpleAwareEventDispatcher;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -29,7 +30,8 @@ class PimpleAwareEventDispatcherTest extends \PHPUnit_Framework_TestCase
         $this->container['foo.service'] = $this->container->share(function() {
             return new FooService;
         });
-        $this->dispatcher = new PimpleAwareEventDispatcher($this->container);
+        $dispatcher = new EventDispatcher;
+        $this->dispatcher = new PimpleAwareEventDispatcher($dispatcher, $this->container);
     }
 
     /**


### PR DESCRIPTION
This would definitely be a BC break. I'm happy to work around it some more if you want something changed. Let me know what you want. :)

All of the tests should still pass. (Works on my machine) I was using [this version in Depot](https://github.com/depot/depot/blob/master/src/Depot/Api/Server/Symfony/EventDispatcher/PimpleContainerAwareEventDispatcher.php) but would love to just have it submitted here.
