### PR TITLE
Support for Symfony ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "pimple/pimple": "3.*",
-        "symfony/event-dispatcher": "~2.1"
+        "symfony/event-dispatcher": "~2.1|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~3.7"

--- a/src/PimpleAwareEventDispatcher/PimpleAwareEventDispatcher.php
+++ b/src/PimpleAwareEventDispatcher/PimpleAwareEventDispatcher.php
@@ -186,6 +186,14 @@ class PimpleAwareEventDispatcher implements EventDispatcherInterface
     /**
      * {@inheritdocs}
      */
+    public function getListenerPriority($eventName, $listener)
+    {
+        return $this->eventDispatcher->getListenerPriority($eventName, $listener);
+    }
+
+    /**
+     * {@inheritdocs}
+     */
     public function hasListeners($eventName = null)
     {
         return $this->eventDispatcher->hasListeners($eventName);


### PR DESCRIPTION
* Update composer dependencies
* Make `PimpleAwareEventDispatcher` compatible with Symfony 2.8+ interface ([details](https://github.com/symfony/symfony/pull/16301)).