### PR TITLE
Update readme example of use to Silex 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,26 +18,26 @@ To use in a [Silex](http://silex.sensiolabs.org) application:
 
 use PimpleAwareEventDispatcher\PimpleAwareEventDispatcher;
 use Silex\Application;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 $app = new Application;
 
-// override the dispatcher
-$app['dispatcher'] = $app['pimple_aware_dispatcher'] = $app->share(
-    $app->extend('dispatcher', function($dispatcher) use ($app) {
-        return new PimpleAwareEventDispatcher($dispatcher, $app);
-    }
-));
+// define the dispatcher
+$app['event_dispatcher'] = function () use ($app) {
+    $dispatcher = new EventDispatcher();
+    return new PimpleAwareEventDispatcher($dispatcher, $app);
+};
 
 // define our application services
-$app['some.service'] = $app->share(function() use ($app) {
+$app['some.service'] = function() use ($app) {
     // let's assume this takes a bit of doing and/or is dependant on several other
     // services
     sleep(1);
     return new SomeService;
-});
+};
 
 // add a listener, that will lazily fetch the service when needed
-$app['pimple_aware_dispatcher']->addListenerService(
+$app['event_dispatcher']->addListenerService(
     "some.event",
     array("some.service", "serviceMethod")
 );


### PR DESCRIPTION
Since Silex container API changed, there is no `shared()` method anymore. Documentation provided on `README.md` needs to be changed after PR https://github.com/davedevelopment/pimple-aware-event-dispatcher/pull/4.

Closes https://github.com/davedevelopment/pimple-aware-event-dispatcher/issues/8